### PR TITLE
Set cross OS config in local-docker.yaml 

### DIFF
--- a/local-helm/environments/local-docker.yaml
+++ b/local-helm/environments/local-docker.yaml
@@ -1,7 +1,7 @@
 dbPassword:
 clientSecret:
-appBaseUrl: "https://docker.for.win.localhost"
-baseIsapiEnabledUrl: "https://docker.for.win.localhost/"
+appBaseUrl: "https://host.docker.internal"
+baseIsapiEnabledUrl: "https://host.docker.internal/"
 
 azurite:
   enabled: true
@@ -74,7 +74,7 @@ isapi-db:
 
 isapi:
   enabled: true
-  disabledUrl: "docker.for.win.localhost"
+  disabledUrl: "host.docker.internal"
   feDisabledIssuerUrl: "localhost"
   replicaCount: 1
   image:
@@ -99,10 +99,12 @@ isapi:
       requirePkce : true
       requireConsent: false
       redirectUrls:         
+        - https://host.docker.internal/oauth/callback
         - https://docker.for.win.localhost/oauth/callback
         - https://docker.for.mac.localhost/oauth/callback
-        - https://docker.for.win.localhost/admin/oauth/callback
+        - https://host.docker.internal/admin/oauth/callback
         - https://docker.for.mac.localhost/admin/oauth/callback
+        - https://docker.for.win.localhost/admin/oauth/callback
         - http://docker.for.win.localhost:3000/oauth/callback
         - http://docker.for.mac.localhost:3000/oauth/callback
         - http://docker.for.win.localhost:3005/admin/oauth/callback
@@ -110,8 +112,10 @@ isapi:
         - http://localhost:3000/oauth/callback
         - http://localhost:3005/admin/oauth/callback
       postLogoutRedirectUrls: 
+        - https://host.docker.internal/signout-callback-oidc
         - https://docker.for.win.localhost/signout-callback-oidc
         - https://docker.for.mac.localhost/signout-callback-oidc
+        - https://host.docker.internal/admin/signout-callback-oidc
         - https://docker.for.win.localhost/admin/signout-callback-oidc
         - https://docker.for.mac.localhost/admin/signout-callback-oidc
         - http://docker.for.win.localhost:3000/signout-callback-oidc
@@ -189,7 +193,7 @@ pb:
       - paths: 
           - /
     tls: []
-  baseUri: "https://docker.for.win.localhost"
+  baseUri: "https://host.docker.internal"
   featureFlags:
     loginEnabled : "true"
     useCapabilitiesSelector: "true"


### PR DESCRIPTION
Changing default uris to host.docker.internal allows all of our used OS's to be able to use the application without additional configuration per OS