### PR TITLE
6439: Overwrite appBaseUrl and baseIsapiEnabledUrl when using mac

### DIFF
--- a/local-helm/README.md
+++ b/local-helm/README.md
@@ -63,7 +63,7 @@ The script will start [all services available on these ports](#configuration-ove
 Ingress is also set up, so the front ends are exposed on localhost, as they would be when running in production.
 
 ### Overrides 
-Overrides in [local-overrides.yaml](local-overrides.yaml) can be set to choose whether to run a component in Kubernetes, or to consider it as running on the developers machine. When a service is disabled, anything that uses that service routes out to the developers machine, using `host.docker.internal`.
+Overrides in [local-overrides.yaml](local-overrides.yaml) can be set to choose whether to run a component in Kubernetes, or to consider it as running on the developers machine. When a service is disabled, anything that uses that service routes out to the developers machine, using `host.docker.internal` or `docker.for.mac.localhost` for mac.
 
 By default cluster spins up containers from latest images built from development branches. You can, however, override this and use a locally build image.
 ```

--- a/local-helm/environments/local-docker-mac.yaml
+++ b/local-helm/environments/local-docker-mac.yaml
@@ -1,0 +1,2 @@
+appBaseUrl: "https://docker.for.mac.localhost"
+baseIsapiEnabledUrl: "https://docker.for.mac.localhost/identity"

--- a/local-helm/launch-or-update-environment.sh
+++ b/local-helm/launch-or-update-environment.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-helm upgrade bc buyingcatalogue -n buyingcatalogue -i -f environments/local-docker.yaml -f local-overrides.yaml $@
+if [[ "$OSTYPE" == "darwin"* ]]; then 
+  helm upgrade bc buyingcatalogue -n buyingcatalogue -i -f environments/local-docker.yaml -f environments/local-docker-mac.yaml -f local-overrides.yaml $@
+else
+  helm upgrade bc buyingcatalogue -n buyingcatalogue -i -f environments/local-docker.yaml -f local-overrides.yaml $@
+fi


### PR DESCRIPTION
[AB#6530](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/6530)