### PR TITLE
6647: Set cookie secret in platform repo for PB and MP

### DIFF
--- a/local-helm/buyingcatalogue/charts/mp/templates/deployment.yaml
+++ b/local-helm/buyingcatalogue/charts/mp/templates/deployment.yaml
@@ -52,7 +52,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.appBaseUri.name | quote }}
-                  key: {{ .Values.appBaseUri.key | quote }}    
+                  key: {{ .Values.appBaseUri.key | quote }}   
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cookieSecret.name }}
+                  key: {{ .Values.cookieSecret.key }}
             {{- if .Values.serviceDependencies }}            
             {{- if .Values.serviceDependencies.bapiUrlConfig }}
             - name: API_HOST              

--- a/local-helm/buyingcatalogue/charts/mp/values.yaml
+++ b/local-helm/buyingcatalogue/charts/mp/values.yaml
@@ -78,7 +78,10 @@ serviceDependencies:
   bapiUrlConfig:
     name: 
     key: 
-
+cookieSecret:
+  name: "bc-buyingcatalogue"
+  key: cookie-secret
+  
 env:
   configmap:
   secrets:

--- a/local-helm/buyingcatalogue/charts/pb/templates/deployment.yaml
+++ b/local-helm/buyingcatalogue/charts/pb/templates/deployment.yaml
@@ -60,7 +60,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: {{ .Values.appBaseUri.name | quote }}
-                  key: {{ .Values.appBaseUri.key | quote }}    
+                  key: {{ .Values.appBaseUri.key | quote }}  
+            - name: COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cookieSecret.name }}
+                  key: {{ .Values.cookieSecret.key }}
             {{- if .Values.serviceDependencies }}
             {{- if .Values.serviceDependencies.redis.urlConfig }}
             - name: REDIS_URL              

--- a/local-helm/buyingcatalogue/values.yaml
+++ b/local-helm/buyingcatalogue/values.yaml
@@ -304,6 +304,9 @@ mp:
     bapiUrlConfig:
       name: "bc-buyingcatalogue"
       key: bapi-url  
+  cookieSecret:
+    name: "bc-buyingcatalogue"
+    key: cookie-secret
 
 pb: 
   enabled: false


### PR DESCRIPTION
added cookie secret config to pb and mp for local, dev, test, prod
[AB#6647](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/6647)