### PR TITLE
6647: Removed cookie secret var from MP

### DIFF
--- a/local-helm/buyingcatalogue/charts/mp/templates/deployment.yaml
+++ b/local-helm/buyingcatalogue/charts/mp/templates/deployment.yaml
@@ -53,11 +53,6 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.appBaseUri.name | quote }}
                   key: {{ .Values.appBaseUri.key | quote }}   
-            - name: COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.cookieSecret.name }}
-                  key: {{ .Values.cookieSecret.key }}
             {{- if .Values.serviceDependencies }}            
             {{- if .Values.serviceDependencies.bapiUrlConfig }}
             - name: API_HOST              

--- a/local-helm/buyingcatalogue/charts/mp/values.yaml
+++ b/local-helm/buyingcatalogue/charts/mp/values.yaml
@@ -78,9 +78,6 @@ serviceDependencies:
   bapiUrlConfig:
     name: 
     key: 
-cookieSecret:
-  name: "bc-buyingcatalogue"
-  key: cookie-secret
   
 env:
   configmap:

--- a/local-helm/buyingcatalogue/values.yaml
+++ b/local-helm/buyingcatalogue/values.yaml
@@ -304,9 +304,6 @@ mp:
     bapiUrlConfig:
       name: "bc-buyingcatalogue"
       key: bapi-url  
-  cookieSecret:
-    name: "bc-buyingcatalogue"
-    key: cookie-secret
 
 pb: 
   enabled: false


### PR DESCRIPTION
[AB#6647](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/6647)
Incorrectly told MP needed this cookie var, removed.
Span cluster locally, MP still working