### PR TITLE
7088: back link from order form to public browse on a mac

### DIFF
--- a/local-helm/environments/local-docker-mac.yaml
+++ b/local-helm/environments/local-docker-mac.yaml
@@ -1,2 +1,5 @@
 appBaseUrl: "https://docker.for.mac.localhost"
 baseIsapiEnabledUrl: "https://docker.for.mac.localhost/identity"
+
+pb:
+  baseUri: "https://docker.for.mac.localhost"


### PR DESCRIPTION
added pb base uri for local docker mac
I want someone on a mac to try this first, I've messaged @kat1906 on Slack

Given I am on order form dashboard on a Mac
And I have checked out this platform branch
And I have relaunched the local cluster
And I am logged in with Alice
And I am on the order form organisation dashboard
When I click return to homepage link
Then I expect to be taken to public browse
And remain logged in

[AB#7088](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7088)